### PR TITLE
Fix Typo

### DIFF
--- a/Lab3b/main.ipynb
+++ b/Lab3b/main.ipynb
@@ -719,7 +719,7 @@
     "Explain what the expression `1 + (decimal and floor(log2(decimal)))` calculates. In particular, explain the purpose of the logical `and` operation in the expression?\n",
     "\n",
     "```{hint}\n",
-    "`floor(log2(decimal))` computes $\\lceil \\log_2 (\\texttt{decimal})\\rceil$, namely, the largest integer no larger than the logarithm base 2 of some number `decimal`.\n",
+    "`floor(log2(decimal))` computes $\\lfloor \\log_2 (\\texttt{decimal})\\rfloor$, namely, the largest integer no larger than the logarithm base 2 of some number `decimal`.\n",
     "- What happen when you run `floor(log2(decimal))` when `decimal` equals `0`?\n",
     "- How about `(decimal and floor(log2(decimal))` when `decimal` equals `0`? Apply the short-circuit evaluation rule.\n",
     "- What does `1 + (decimal and floor(log2(decimal)))` return when `decimal` is between $2^{\\ell} \\leq \\texttt{decimal} < 2^{\\ell + 1}$?\n",


### PR DESCRIPTION
Hey professor, In **Lab3b**, the `Hint` Part of `Exercise (logical-and)` says that

> `floor(log2(decimal))` computes $\lceil \log_2 (\texttt{decimal})\rceil$, namely, the largest integer no larger than the logarithm base 2 of some number `decimal`.

It's clear that it should be $\lfloor \log_2 (\texttt{decimal})\rfloor$.

I have fixed it and please merge the pull request. Thank you!